### PR TITLE
tests.LoginTest need to share an instance of WebDriver with utils.listener.TestListener; an possible alternative implementation using ITestContext

### DIFF
--- a/src/test/java/tests/BaseTest.java
+++ b/src/test/java/tests/BaseTest.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -12,7 +14,7 @@ import pages.HomePage;
 import utils.logs.Log;
 
 public class BaseTest {
-    public WebDriver driver;
+    private WebDriver driver;
     public HomePage homePage;
 
     public WebDriver getDriver() {
@@ -20,12 +22,12 @@ public class BaseTest {
     }
 
     @BeforeSuite
-    public void setupProxy() {
+    public void setupProxy(ITestContext iTestContext) {
 
     }
 
     @BeforeClass
-    public void classLevelSetup() {
+    public void classLevelSetup(ITestContext iTestContext) {
         Log.info("Tests is starting!");
 
         FirefoxOptions firefoxOptions = new FirefoxOptions();
@@ -36,6 +38,7 @@ public class BaseTest {
 
         firefoxOptions.setCapability("proxy", proxy);
         driver = new FirefoxDriver(firefoxOptions);
+        iTestContext.setAttribute("WebDriver", driver);
     }
 
     @BeforeMethod


### PR DESCRIPTION
Thank you for your great article https://www.swtestacademy.com/extent-reports-in-selenium-with-testng/ It helped me a lot. Let me post my small pull request.

[utils.listener.TestListner#onTestFailure()](https://github.com/kazurayam/ExtentReportsExample/blob/master/src/test/java/utils/listeners/TestListener.java) is designed to take a screenshot of the browser on a failure detected by the [@Test-annotated method of tests.LoginTest](https://github.com/kazurayam/ExtentReportsExample/blob/master/src/test/java/tests/LoginTests.java). TestListener need to have a reference to the instance of `WebDriver` which was created by the LoginTest class. 

Here is a technical issue. The Test class creates a WebDriver instance; The Test Listener need a reference to the WebDriver instance. How to share the WebDriver instance between the two? 

There could be multiple design options. The original [utils.listener.TestListner#onTestFailure()](https://github.com/kazurayam/ExtentReportsExample/blob/master/src/test/java/utils/listeners/TestListener.java) gets access to the WebDriver instance by the following 2 lines of code:

```
    @Override
    public void onTestFailure(ITestResult iTestResult) {
        ...
        Object testClass = iTestResult.getInstance();
        WebDriver driver = ((BaseTest) testClass).getDriver();
```

OK. This certainly works. However I find two issues in the original code.

## Issue1 : `utils.listener.TestListener` extends `tests.BaseTest`, which is unnecessary

I think that the author possibly forgot to erase the inheritance.

## Issue2 : Should use ITestContext

we should rather use TestNG `ITestContext`to share the WebDriver instance between the Test class and the TestListener. For example, the `test.BaseTest` should say

```
public class BaseTet {
    ...
    private WebDriver driver;
    ...
    @BeforeClass
    public void classLevelSetup(ITestContext context) {
        ....
        context.setAttribute("WebDriver", driver)
        }

}
```

The following article told me of the coding gotcha.

- https://www.softwaretestingo.com/itestcontext-testng/

Is there any official documentation that describes that we can write `ITestContext` object as a prameter for `@BeforeXXX`-annotated method?  ... Yes. See the following.

- https://testng-docs.readthedocs.io/fulldoc/#native-dependency-injection

